### PR TITLE
Add rag ingestion worker service

### DIFF
--- a/services/rag-ingestion-worker/README.md
+++ b/services/rag-ingestion-worker/README.md
@@ -1,0 +1,23 @@
+# RAG Ingestion Worker
+
+This service provisions an SQS queue and a Lambda function that dequeues
+messages to start the RAG ingestion workflow. Each message body is passed
+unchanged to the Step Function identified by the ``STATE_MACHINE_ARN``
+environment variable.
+
+## Parameters
+
+- ``StateMachineArn`` – ARN of the ingestion Step Function. This value becomes
+the ``STATE_MACHINE_ARN`` environment variable for the worker.
+
+## Deployment
+
+Deploy with SAM:
+
+```bash
+sam deploy \
+  --template-file services/rag-ingestion-worker/template.yaml \
+  --stack-name rag-ingestion-worker \
+  --parameter-overrides \
+    StateMachineArn=<arn>
+```

--- a/services/rag-ingestion-worker/template.yaml
+++ b/services/rag-ingestion-worker/template.yaml
@@ -1,0 +1,42 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Worker processing the RAG ingestion queue.
+
+Parameters:
+  StateMachineArn:
+    Type: String
+
+Globals:
+  Function:
+    Handler: app.lambda_handler
+    Runtime: python3.13
+    Timeout: 60
+    MemorySize: 512
+
+Resources:
+  IngestionQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      VisibilityTimeout: 300
+
+  WorkerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./worker-lambda/
+      Environment:
+        Variables:
+          STATE_MACHINE_ARN: !Ref StateMachineArn
+      Events:
+        Queue:
+          Type: SQS
+          Properties:
+            Queue: !GetAtt IngestionQueue.Arn
+            BatchSize: 1
+
+Outputs:
+  QueueUrl:
+    Description: URL of the ingestion queue
+    Value: !Ref IngestionQueue
+  WorkerFunctionArn:
+    Description: ARN of the ingestion worker Lambda
+    Value: !GetAtt WorkerFunction.Arn

--- a/services/rag-ingestion-worker/worker-lambda/app.py
+++ b/services/rag-ingestion-worker/worker-lambda/app.py
@@ -1,0 +1,40 @@
+"""Worker Lambda invoking the RAG ingestion state machine."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict
+
+import boto3
+from botocore.exceptions import ClientError
+from common_utils import configure_logger
+
+logger = configure_logger(__name__)
+
+STATE_MACHINE_ARN = os.environ.get("STATE_MACHINE_ARN")
+if not STATE_MACHINE_ARN:
+    raise RuntimeError("STATE_MACHINE_ARN not configured")
+
+sfn = boto3.client("stepfunctions")
+
+
+def _process_record(record: Dict[str, Any]) -> None:
+    payload = json.loads(record.get("body", "{}"))
+    sfn.start_execution(
+        stateMachineArn=STATE_MACHINE_ARN,
+        input=json.dumps(payload),
+    )
+
+
+def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    for record in event.get("Records", []):
+        try:
+            _process_record(record)
+        except ClientError as exc:
+            logger.error("Failed to start state machine: %s", exc)
+            return {"started": False, "error": str(exc)}
+        except Exception as exc:  # pragma: no cover - unexpected runtime error
+            logger.exception("Unexpected error starting state machine")
+            return {"started": False, "error": str(exc)}
+    return {"started": True}

--- a/template.yaml
+++ b/template.yaml
@@ -86,6 +86,13 @@ Resources:
         BucketName: !GetAtt IDPService.Outputs.BucketName
         TextDocPrefix: !GetAtt IDPService.Outputs.TextDocPrefix
 
+  RagIngestionWorkerService:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: services/rag-ingestion-worker/template.yaml
+      Parameters:
+        StateMachineArn: !GetAtt RagIngestionService.Outputs.IngestionStateMachineArn
+
   RagRetrievalService:
     Type: AWS::Serverless::Application
     Properties:

--- a/tests/test_rag_ingestion_worker.py
+++ b/tests/test_rag_ingestion_worker.py
@@ -1,0 +1,50 @@
+import importlib.util
+import json
+import sys
+import types
+
+
+def _stub_botocore(monkeypatch):
+    botocore = types.ModuleType("botocore")
+    exc_mod = types.ModuleType("botocore.exceptions")
+
+    class ClientError(Exception):
+        pass
+
+    exc_mod.ClientError = ClientError
+    botocore.exceptions = exc_mod
+    monkeypatch.setitem(sys.modules, "botocore", botocore)
+    monkeypatch.setitem(sys.modules, "botocore.exceptions", exc_mod)
+    return ClientError
+
+
+def load_lambda(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_worker_triggers_step_function(monkeypatch, config):
+    calls = {}
+
+    _stub_botocore(monkeypatch)
+
+    class FakeSFN:
+        def start_execution(self, stateMachineArn=None, input=None):
+            calls['arn'] = stateMachineArn
+            calls['input'] = json.loads(input)
+            return {}
+
+    import boto3
+    monkeypatch.setattr(boto3, 'client', lambda name: FakeSFN())
+    monkeypatch.setenv('STATE_MACHINE_ARN', 'arn')
+
+    module = load_lambda('worker', 'services/rag-ingestion-worker/worker-lambda/app.py')
+    module.sfn = FakeSFN()
+
+    event = {'Records': [{'body': json.dumps({'foo': 'bar'})}]}
+    out = module.lambda_handler(event, {})
+    assert out['started'] is True
+    assert calls['arn'] == 'arn'
+    assert calls['input'] == {'foo': 'bar'}


### PR DESCRIPTION
## Summary
- add rag-ingestion-worker Lambda that dequeues messages and starts the ingestion Step Function
- wire worker stack into parent template
- document worker parameters and deployment
- test worker Lambda behaviour

## Testing
- `pytest tests/test_rag_ingestion_worker.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyPDF2')*

------
https://chatgpt.com/codex/tasks/task_e_68694092a004832f84b20c0cdbae449d