### PR TITLE
Update ingestion worker docs

### DIFF
--- a/services/rag-ingestion-worker/README.md
+++ b/services/rag-ingestion-worker/README.md
@@ -21,3 +21,32 @@ sam deploy \
   --parameter-overrides \
     StateMachineArn=<arn>
 ```
+
+## Queue visibility timeout and DLQ
+
+The SQS queue ``IngestionQueue`` defined in ``template.yaml`` uses a
+``VisibilityTimeout`` of **300 seconds**. When a message is delivered to the
+worker Lambda it remains invisible to other consumers for five minutes. If the
+Lambda fails or times out the message becomes visible again after this period
+and is retried.  The stack does not configure a dead-letter queue by default, so
+messages that repeatedly fail stay on the main queue until they are processed or
+expire.  Add a ``RedrivePolicy`` to ``IngestionQueue`` if you need a DLQ for
+poison messages.
+
+## Batch item failure handling
+
+Messages are dequeued one at a time (``BatchSize: 1``).  The handler processes
+each record and returns a JSON result. When the Lambda execution fails or raises
+an exception the message is returned to the queue and retried after the
+visibility timeout.  Because the current implementation catches exceptions and
+returns a success response, failed Step Function starts are not automatically
+retried. Modify the handler to raise an error or implement the SQS
+``batchItemFailures`` response format if retries are required.
+
+## Lambda scaling and environment variables
+
+``STATE_MACHINE_ARN`` is the only environment variable exposed by the stack and
+identifies the Step Function to invoke.  The Lambda scales automatically based
+on the number of messages in the queue.  Throughput can be tuned by adjusting
+the function's reserved concurrency or the queue event source configuration in
+``template.yaml``.


### PR DESCRIPTION
## Summary
- document visibility timeout and DLQ options
- describe batch item failure handling and retries
- add scaling and environment variable notes to the worker docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'services.file_ingestion', ModuleNotFoundError: No module named 'PyPDF2')*

------
https://chatgpt.com/codex/tasks/task_e_6869491ee1d8832fa4256eba11b450d6